### PR TITLE
Fix for weapon effects E20 update

### DIFF
--- a/module.json
+++ b/module.json
@@ -19,8 +19,8 @@
         "type": "system",
         "compatibility": [
           {
-            "minimum": "3.1.4",
-            "verified": "3.1.4"
+            "minimum": "4.0.0",
+            "verified": "4.0.1"
           }
         ]
       }

--- a/scripts/action-handler.js
+++ b/scripts/action-handler.js
@@ -50,11 +50,38 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
       }
     }
 
+    /*
+      Weapon effect groups are added dynamically for each weapon
+    */
     _addWeaponsActions(actor) {
-      this._addActionHelper(
-        this._getActionsForItemType(ITEMS.weapons.type, actor),
-        ITEMS.weapons.id,
-      );
+      const weapons = actor.items.filter((i) => !!i && i.type == ITEMS.weapons.type);
+      for (const weapon of weapons) {
+        // Create a group for this weapon (such as Blade Blaster)
+        const weaponGroupId = `${ITEMS.weapons.id}-${weapon.id}`;
+        this.addGroup(
+          {
+            id: weaponGroupId,
+            name: weapon.name,
+            type: 'system',
+          },
+          {
+            id: ITEMS.weapons.id,
+            type: 'system',
+          },
+        );
+
+        // Get the actions for all the weapon's effects, to be added into this weapon group
+        const weaponEffectsActions = actor.items.filter(
+          // Find all the weaponEffects whose id is in this weapon's list of weaponEffectIds
+          (i) => !!i && i.type == ITEMS.weaponEffects.type && weapon.system.weaponEffectIds.includes(i.id))
+          .map((i) => {
+            let encodedValue = [MACRO_TYPES.item, i.id].join(this.delimiter);
+            return { name: i.name, encodedValue: encodedValue, id: i.id };
+          });
+
+        // Finally, add the effects/actions for this weapon
+        this._addActionHelper(weaponEffectsActions, weaponGroupId);
+      }
     }
 
     _addPowersActions(actor) {

--- a/scripts/defaults.js
+++ b/scripts/defaults.js
@@ -42,6 +42,12 @@ export const ITEMS = {
     infoId: 'id-info-weapons',
     type: 'weapon',
   },
+  weaponEffects: {
+    name: "Weapon Effect",
+    id: 'id-weapon-effects',
+    infoId: 'id-info-weapon-effects',
+    type: 'weaponEffect',
+  },
   armor: {
     name: "Armor",
     infoId: 'id-info-armor',


### PR DESCRIPTION
In this PR:
- v4.0.0 of the Essence20 system introduce weapon effects, which are now the items used for attack rolls instead of weapons. This broke the E20 TAH weapon rolling, so this PR fixes that.
- Weapon effects are grouped by weapons, and can be clicked to roll

Testing:
- Weapon effects should be grouped by weapons
- Clicking on a weapon effect performs the correct roll