### PR TITLE
Fixes for TAH Core 1.4.19

### DIFF
--- a/scripts/defaults.js
+++ b/scripts/defaults.js
@@ -43,7 +43,7 @@ export const ITEMS = {
     type: 'weapon',
   },
   weaponEffects: {
-    name: "Weapon Effect",
+    name: "Weapon Effects",
     id: 'id-weapon-effects',
     infoId: 'id-info-weapon-effects',
     type: 'weaponEffect',
@@ -175,14 +175,6 @@ export const DEFAULTS = {
       nestId: ITEMS.weapons.id,
       id: ITEMS.weapons.id,
       name: ITEMS.weapons.name,
-      groups: [
-        {
-          type: 'system',
-          nestId: `${ITEMS.weapons.id}_${ITEMS.weapons.id}`,
-          id: ITEMS.weapons.id,
-          name: "",
-        },
-      ],
     },
     {
       type: 'system',
@@ -214,6 +206,12 @@ export const DEFAULTS = {
           nestId: `${INFO_ID}_${ITEMS.weapons.infoId}`,
           id: ITEMS.weapons.infoId,
           name: ITEMS.weapons.name,
+        },
+        {
+          type: 'system',
+          nestId: `${INFO_ID}_${ITEMS.weaponEffects.infoId}`,
+          id: ITEMS.weaponEffects.infoId,
+          name: ITEMS.weaponEffects.name,
         },
         {
           type: 'system',


### PR DESCRIPTION
In this PR:
- Weapon groups show duplicate weapon effects once TAH Core is updated to 1.4.19 because I messed up the weapon groups setup. This should no longer show duplicates.
- Confirmed working functionality up to v.1.4.22
- Now shows weapon effects in the Info group
- Pluralizing "Weapon Effect" name

Testing:
- Update TAH Core to v1.4.22 by using this manifest URL: https://github.com/Larkinabout/fvtt-token-action-hud-core/releases/download/1.4.22/module.json
- Groups should appear as normal, without weapon effect duplicates