### PR TITLE
Adding support for TAH Core v1.5

### DIFF
--- a/module.json
+++ b/module.json
@@ -4,8 +4,8 @@
   "description": "Provide support for the Essence20 game system with Token Action HUD Core",
   "version": "This is auto replaced",
   "compatibility": {
-    "minimum": 10,
-    "verified": 10
+    "minimum": 11,
+    "verified": 11.301
   },
   "authors": [
     {
@@ -31,9 +31,9 @@
         "type": "module",
         "compatibility": [
           {
-            "minimum": "1.4",
-            "verified": "1.4",
-            "maximum": "1.4"
+            "minimum": "1.5",
+            "verified": "1.5",
+            "maximum": "1.5"
           }
         ]
       }

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -15,7 +15,7 @@ export const CORE_MODULE = {
 /**
  * Core module version required by the system module
  */
-export const REQUIRED_CORE_MODULE_VERSION = '1.4';
+export const REQUIRED_CORE_MODULE_VERSION = '1.5';
 
 /**
  * Macro types used in encoded strings and RollHandler

--- a/scripts/roll-handler.js
+++ b/scripts/roll-handler.js
@@ -5,7 +5,7 @@ export let RollHandler = null;
 Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
   RollHandler = class RollHandler extends coreModule.api.RollHandler {
     /** @override */
-    async doHandleActionEvent(event, encodedValue) {
+    async dandleActionEvent(event, encodedValue) {
       let payload = encodedValue.split("|");
 
       const macroType = payload[0];
@@ -13,7 +13,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
 
       if (this.isRenderItem()) {
         if (macroType == MACRO_TYPES.info) {
-          this.doRenderItem(this.actor, actionId);
+          this.renderItem(this.actor, actionId);
         }
         return;
       }

--- a/scripts/roll-handler.js
+++ b/scripts/roll-handler.js
@@ -1,20 +1,22 @@
 import { MACRO_TYPES } from './constants.js';
+import { Utils } from "./utils.js";
 
 export let RollHandler = null;
 
 Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
   RollHandler = class RollHandler extends coreModule.api.RollHandler {
     /** @override */
-    async dandleActionEvent(event, encodedValue) {
+    async doHandleActionEvent(event, encodedValue) {
       let payload = encodedValue.split("|");
 
       const macroType = payload[0];
       const actionId = payload[1];
 
-      if (this.isRenderItem()) {
+      if (Utils.getSetting('renderItemOnRightClick') && this.isRenderItem()) {
         if (macroType == MACRO_TYPES.info) {
           this.renderItem(this.actor, actionId);
         }
+
         return;
       }
 

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -1,0 +1,20 @@
+import { MODULE } from './constants.js'
+
+/**
+ * Register module settings
+ * Called by Token Action HUD Core to register Token Action HUD system module settings
+ * @param {function} coreUpdate Token Action HUD Core update function
+ */
+export function register(coreUpdate) {
+  game.settings.register(MODULE.ID, 'renderItemOnRightClick', {
+    name: "Open Item Sheet on Right-Click",
+    hint: "When right-clicking an item, open the item's sheet",
+    scope: 'client',
+    config: true,
+    type: Boolean,
+    default: true,
+    onChange: (value) => {
+      onChangeFunction('renderItemOnRightClick', value);
+    },
+  });
+}

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -14,7 +14,7 @@ export function register(coreUpdate) {
     type: Boolean,
     default: true,
     onChange: (value) => {
-      onChangeFunction('renderItemOnRightClick', value);
+      coreUpdate(value)
     },
   });
 }

--- a/scripts/system-manager.js
+++ b/scripts/system-manager.js
@@ -1,6 +1,7 @@
 import { ActionHandler as ActionHandler } from "./action-handler.js";
 import { RollHandler as Core } from "./roll-handler.js";
 import { DEFAULTS } from './defaults.js';
+import { register } from './settings.js';
 
 export let SystemManager = null;
 
@@ -26,8 +27,14 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
       return new Core();
     }
 
+    /** @override */
     async registerDefaults() {
       return DEFAULTS;
+    }
+
+    /** @override */
+    registerSettings(coreUpdate) {
+      register(coreUpdate);
     }
   }
 });

--- a/scripts/system-manager.js
+++ b/scripts/system-manager.js
@@ -12,7 +12,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
     }
 
     /** @override */
-    doGetActionHandler(categoryManager) {
+    getActionHandler(categoryManager) {
       return new ActionHandler(categoryManager);
     }
 
@@ -22,11 +22,11 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
     }
 
     /** @override */
-    doGetRollHandler(handlerId) {
+    getRollHandler(handlerId) {
       return new Core();
     }
 
-    async doRegisterDefaultFlags() {
+    async registerDefaults() {
       return DEFAULTS;
     }
   }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,0 +1,40 @@
+import { MODULE } from './constants.js'
+
+export let Utils = null
+
+Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
+  /**
+   * Utility functions
+   */
+  Utils = class Utils {
+    /**
+     * Get setting
+     * @param {string} key               The key
+     * @param {string=null} defaultValue The default value
+     * @returns {string}                 The setting value
+     */
+    static getSetting(key, defaultValue = null) {
+      let value = defaultValue ?? null
+      try {
+        value = game.settings.get(MODULE.ID, key)
+      } catch {
+        coreModule.api.Logger.debug(`Setting '${key}' not found`)
+      }
+      return value
+    }
+
+    /**
+     * Set setting
+     * @param {string} key   The key
+     * @param {string} value The value
+     */
+    static async setSetting(key, value) {
+      try {
+        value = await game.settings.set(MODULE.ID, key, value)
+        coreModule.api.Logger.debug(`Setting '${key}' set to '${value}'`)
+      } catch {
+        coreModule.api.Logger.debug(`Setting '${key}' not found`)
+      }
+    }
+  }
+})


### PR DESCRIPTION
In this PR:
- Replacing deprecated method names with new ones
- Right clicking an item to render its sheet was removed from Core, so I'm supporting it as part of this module

Testing:
- Make sure you're on TAH Core v1.5
- Should work as normal
- Right clicking an item in the Info section should render its sheet
  - Unchecking this in the TAH E20 settings should no longer render the sheet