### PR TITLE
Fixing weapon effect actions

### DIFF
--- a/scripts/action-handler.js
+++ b/scripts/action-handler.js
@@ -71,12 +71,13 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
         );
 
         // Get the actions for all the weapon's effects, to be added into this weapon group
-        const weaponEffectsActions = actor.items.filter(
-          // Find all the weaponEffects whose id is in this weapon's list of weaponEffectIds
-          (i) => !!i && i.type == ITEMS.weaponEffects.type && weapon.system.weaponEffectIds.includes(i.id))
+        const weaponEffectsActions = Object.values(weapon.system.items).filter(
+          // Find all the weapon's weapon effects
+          (i) => !!i && i.type == ITEMS.weaponEffects.type)
           .map((i) => {
-            let encodedValue = [MACRO_TYPES.item, i.id].join(this.delimiter);
-            return { name: i.name, encodedValue: encodedValue, id: i.id };
+            const weaponEffectId = i.uuid.split('.')[3]; // uuid -> id
+            let encodedValue = [MACRO_TYPES.item, weaponEffectId].join(this.delimiter);
+            return { name: i.name, encodedValue: encodedValue, id: weaponEffectId };
           });
 
         // Finally, add the effects/actions for this weapon

--- a/scripts/action-handler.js
+++ b/scripts/action-handler.js
@@ -72,8 +72,8 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
 
         // Get the actions for all the weapon's effects, to be added into this weapon group
         const weaponEffectsActions = this.actor.items.filter(
-          // Find all the weapon's weapon effects
-          (i) => !!i && i.type == ITEMS.weaponEffects.type && i.getFlag('essence20', 'parentId') == weapon.id)
+          // Find all the weapon's weapon effects by comparing the parentId (ID or UUID) to the weapon's ID
+          (i) => !!i && i.type == ITEMS.weaponEffects.type && i.getFlag('essence20', 'parentId')?.split('.').slice(-1) == weapon.id)
           .map((i) => {
             const weaponEffectId = i.uuid;
             let encodedValue = [MACRO_TYPES.item, weaponEffectId].join(this.delimiter);

--- a/scripts/action-handler.js
+++ b/scripts/action-handler.js
@@ -71,11 +71,11 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
         );
 
         // Get the actions for all the weapon's effects, to be added into this weapon group
-        const weaponEffectsActions = Object.values(weapon.system.items).filter(
+        const weaponEffectsActions = this.actor.items.filter(
           // Find all the weapon's weapon effects
-          (i) => !!i && i.type == ITEMS.weaponEffects.type)
+          (i) => !!i && i.type == ITEMS.weaponEffects.type && i.getFlag('essence20', 'parentId') == weapon.id)
           .map((i) => {
-            const weaponEffectId = i.uuid.split('.')[3]; // uuid -> id
+            const weaponEffectId = i.uuid;
             let encodedValue = [MACRO_TYPES.item, weaponEffectId].join(this.delimiter);
             return { name: i.name, encodedValue: encodedValue, id: weaponEffectId };
           });
@@ -102,8 +102,8 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
     _getActionsForItemType(type, actor, actionId = MACRO_TYPES.item) {
       return actor.items.filter((i) => !!i && i.type == type)
         .map((i) => {
-          let encodedValue = [actionId, i.id].join(this.delimiter);
-          return { name: i.name, encodedValue: encodedValue, id: i.id };
+          let encodedValue = [actionId, i.uuid].join(this.delimiter);
+          return { name: i.name, encodedValue: encodedValue, id: i.uuid };
         });
     }
   }

--- a/scripts/roll-handler.js
+++ b/scripts/roll-handler.js
@@ -39,7 +39,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
     }
 
     rollItemMacro(actionId, dataset = {}) {
-      const item = this.actor.items.find((i) => i.id === actionId);
+      const item = this.actor.items.find((i) => i.uuid === actionId);
       if (item) {
         item.roll(dataset);
       }


### PR DESCRIPTION
In this PR:
- Fixing weapon actions that were broken due to changes in the Essence20 system
- Using UUIDs instead of IDs
- Matching weapon effects with their weapons using the `parentId` flag

Testing:
- Weapon actions should now be showing up and working as normal again