### PR TITLE
Replacing deprecated method; Bumping compatibility versions

### DIFF
--- a/module.json
+++ b/module.json
@@ -32,8 +32,7 @@
         "compatibility": [
           {
             "minimum": "1.5",
-            "verified": "1.5",
-            "maximum": "1.5"
+            "verified": "1.5.4"
           }
         ]
       }

--- a/scripts/roll-handler.js
+++ b/scripts/roll-handler.js
@@ -6,7 +6,7 @@ export let RollHandler = null;
 Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
   RollHandler = class RollHandler extends coreModule.api.RollHandler {
     /** @override */
-    async doHandleActionEvent(event, encodedValue) {
+    async handleActionClick(event, encodedValue) {
       let payload = encodedValue.split("|");
 
       const macroType = payload[0];


### PR DESCRIPTION
In this PR:
- Using `handleActionClick` instead of deprecated `doHandleActionEvent`
- Bumping TAH Core compatibility versions

Testing:
- Updating TAH to the latest version (1.5.4) and everything should work as normal
- No deprecation warning when clicking a button